### PR TITLE
Making the ini script for KappaTools appliable for both bash and zsh

### DIFF
--- a/Toolbox/scripts/ini_KappaTools.sh
+++ b/Toolbox/scripts/ini_KappaTools.sh
@@ -1,12 +1,28 @@
 #!/bin/bash
 
-# get path of KappaTools installation
-if [[ ${BASH_SOURCE[0]} == *"${CMSSW_BASE}/bin/"* || ${BASH_SOURCE[0]} == *"${CMSSW_BASE}/src/KappaTools/"* ]]; then
-	export KAPPATOOLSPATH=$CMSSW_BASE/src/KappaTools
-else
-	# get KappaTools dir relative to location of this script
-	export KAPPATOOLSPATH=$(readlink -f $(dirname $(readlink -f ${BASH_SOURCE[0]}))/../..)
+if [ -n "$BASH_VERSION" ]; then
+
+	# get path of KappaTools installation for bash
+	if [[ ${BASH_SOURCE[0]} == *"${CMSSW_BASE}/bin/"* || ${BASH_SOURCE[0]} == *"${CMSSW_BASE}/src/KappaTools/"* ]]; then
+		export KAPPATOOLSPATH=$CMSSW_BASE/src/KappaTools
+	else
+		# get KappaTools dir relative to location of this script for bash
+		export KAPPATOOLSPATH=$(readlink -f $(dirname $(readlink -f ${BASH_SOURCE[0]}))/../..)
+	fi
+
+elif [ -n "$ZSH_VERSION" ]; then
+
+	# get path of KappaTools installation for zsh
+	if [[ ${0} == *"${CMSSW_BASE}/bin/"* || ${0} == *"${CMSSW_BASE}/src/KappaTools/"* ]]; then
+		export KAPPATOOLSPATH=$CMSSW_BASE/src/KappaTools
+	else
+		# get KappaTools dir relative to location of this script for zsh
+		export KAPPATOOLSPATH=$(readlink -f -- $(dirname  -- "$(readlink -f -- "${0}")")/../..)
+	fi
+
 fi
+
+export SCRAM_IGNORE_PACKAGES="KappaTools/PythonTools"
 
 export KAPPAPATH=$(readlink -f $KAPPATOOLSPATH/../Kappa)
 


### PR DESCRIPTION
The KappaTools ini script has now also possibility to be sourced in bash and zsh. Please test it again to make sure, that it works for you.
