### PR TITLE
Reading out of Runs tree in Kappa files

### DIFF
--- a/Example/bin/minimal.cpp
+++ b/Example/bin/minimal.cpp
@@ -22,13 +22,13 @@ int main(int argc, char **argv)
 
 	FileInterface2Adv fi(files);
 
-	std::vector<std::string> names = fi.GetNames<KBasicJets>();
+	std::vector<std::string> names = fi.GetEventNames<KBasicJets>();
 	cout << "Available PF Jets: " << names << endl;
 
 	// Retrieve first PFJet collection and per event / per lumi metadata
-	KBasicJets *jets = fi.Get<KBasicJets>(names[0]);
-	KEventInfo *meta_event = fi.Get<KEventInfo>();
-	//KLumiInfo *meta_lumi = fi.GetMeta<KLumiInfo>("KLumiInfo");
+	KBasicJets *jets = fi.GetEvent<KBasicJets>(names[0]);
+	KEventInfo *meta_event = fi.GetEvent<KEventInfo>();
+	//KLumiInfo *meta_lumi = fi.GetLumi<KLumiInfo>("KLumiInfo");
 
 	// Interface for output / booking histograms
 	PlotInterface pi("output.root", PlotInterface::reset);
@@ -49,7 +49,7 @@ int main(int argc, char **argv)
 		if (lsWatcher.Changed(meta_event))
 		{
 //			cout << "Reading new lumi metadata!" << endl;
-			fi.GetMetaEntry();
+			fi.GetLumiEntry();
 //			cout << "Lumi metadata: " << *meta_lumi << endl;
 		}
 

--- a/Example/bin/minimal.cpp
+++ b/Example/bin/minimal.cpp
@@ -36,14 +36,14 @@ int main(int argc, char **argv)
 	TH1D *pt_spec_inc = pi.book<TH1D>("pt_spec", "dN/dp_{T} - inclusive",
 		Variable(LogBinning(30, 10, 3000), "p_{T} [GeV]"));
 
-	long long nEvents = fi.eventdata.GetEntries();
+	long long nEvents = fi.eventdata->GetEntries();
 	cout << "Processing " << nEvents << " events" << endl;
 	ProgressMonitor pm(nEvents);
 	fi.SpeedupTree();
 	for (long long iEvent = 0; iEvent < nEvents; ++iEvent)
 	{
 		if (!pm.Update()) break;
-		fi.eventdata.GetEntry(iEvent);
+		fi.eventdata->GetEntry(iEvent);
 
 		static LSWatcher lsWatcher;
 		if (lsWatcher.Changed(meta_event))

--- a/Example/bin/minimal_disc.cpp
+++ b/Example/bin/minimal_disc.cpp
@@ -22,16 +22,16 @@ int main(int argc, char **argv)
 
 	FileInterface2Adv fi(files);
 
-	std::vector<std::string> names = fi.GetNames<KBasicJets>();
+	std::vector<std::string> names = fi.GetEventNames<KBasicJets>();
 	cout << "Available PF Jets: " << names << endl;
-	cout << "Available PF Taus: " << fi.GetNames<KTaus>() << endl;
+	cout << "Available PF Taus: " << fi.GetEventNames<KTaus>() << endl;
 
 	// Retrieve first PFJet collection and per event / per lumi metadata
-	KBasicJets *jets = fi.Get<KBasicJets>(names[0]);
-	KTaus *taus = fi.Get<KTaus>("hpsPFTaus");
-	KEventInfo *meta_event = fi.Get<KEventInfo>();
-	//KLumiInfo *meta_lumi = fi.GetMeta<KLumiInfo>("KLumiInfo");
-	KTauMetadata *meta_taudisc = fi.GetMeta<KTauMetadata>("hpsPFTaus");
+	KBasicJets *jets = fi.GetEvent<KBasicJets>(names[0]);
+	KTaus *taus = fi.GetEvent<KTaus>("hpsPFTaus");
+	KEventInfo *meta_event = fi.GetEvent<KEventInfo>();
+	//KLumiInfo *meta_lumi = fi.GetLumi<KLumiInfo>("KLumiInfo");
+	KTauMetadata *meta_taudisc = fi.GetLumi<KTauMetadata>("hpsPFTaus");
 
 	// Interface for output / booking histograms
 	PlotInterface pi("output.root", PlotInterface::reset);
@@ -52,7 +52,7 @@ int main(int argc, char **argv)
 		if (lsWatcher.Changed(meta_event))
 		{
 //			cout << "Reading new lumi metadata!" << endl;
-			fi.GetMetaEntry();
+			fi.GetLumiEntry();
 //			cout << "Lumi metadata: " << *meta_lumi << endl;
 //			cout << "Tau metadata: " << *meta_taudisc << endl;
 		}

--- a/Example/bin/minimal_disc.cpp
+++ b/Example/bin/minimal_disc.cpp
@@ -39,14 +39,14 @@ int main(int argc, char **argv)
 	TH1D *pt_spec_inc = pi.book<TH1D>("pt_spec", "dN/dp_{T} - inclusive",
 		Variable(LogBinning(30, 10, 3000), "p_{T} [GeV]"));
 
-	long long nEvents = fi.eventdata.GetEntries();
+	long long nEvents = fi.eventdata->GetEntries();
 	cout << "Processing " << nEvents << " events" << endl;
 	ProgressMonitor pm(nEvents);
 	fi.SpeedupTree();
 	for (long long iEvent = 0; iEvent < nEvents; ++iEvent)
 	{
 		if (!pm.Update()) break;
-		fi.eventdata.GetEntry(iEvent);
+		fi.eventdata->GetEntry(iEvent);
 
 		static LSWatcher lsWatcher;
 		if (lsWatcher.Changed(meta_event))

--- a/Example/test/test.cpp
+++ b/Example/test/test.cpp
@@ -54,7 +54,7 @@ int main(int argc, char **argv)
 		if (lsWatcher.Changed(meta_event))
 			cout << "Reading new lumi metadata!" << endl;
 		KLumiInfo *meta_lumi = fi.Get<KLumiInfo>(meta_event);
-		KGenLumiInfo *meta_lumi_gen = fi.Get<KGenLumiInfo>(meta_event);
+		KGenRunInfo *meta_lumi_gen = fi.Get<KGenRunInfo>(meta_event);
 
 		if (meta_event->bitsHLT.size() == 0)
 			continue;

--- a/Example/test/test.cpp
+++ b/Example/test/test.cpp
@@ -40,15 +40,15 @@ int main(int argc, char **argv)
 
 	KEventInfo *meta_event = fi.Get<KEventInfo>();
 
-//	long long nEvents = min((long long)3, fi.eventdata.GetEntries());
-	long long nEvents = fi.eventdata.GetEntries();
+//	long long nEvents = min((long long)3, fi.eventdata->GetEntries());
+	long long nEvents = fi.eventdata->GetEntries();
 	std::cout << nEvents << std::endl;
 	ProgressMonitor pm(nEvents);
 	fi.SpeedupTree();
 	for (long long iEvent = 0; iEvent < nEvents; ++iEvent)
 	{
 		if (!pm.Update()) break;
-		fi.eventdata.GetEntry(iEvent);
+		fi.eventdata->GetEntry(iEvent);
 
 		static LSWatcher lsWatcher;
 		if (lsWatcher.Changed(meta_event))

--- a/Example/test/test.cpp
+++ b/Example/test/test.cpp
@@ -26,19 +26,19 @@ int main(int argc, char **argv)
 	ssf.finish(fi.GetEntries(), 1, 1);
 
 	std::cout << "finished" << std::endl;
-	vector<string> names = fi.GetNames<KLVs>();
+	vector<string> names = fi.GetEventNames<KLVs>();
 	cout << names << endl << endl;
 	if (names.size() == 0)
 		return -1;
 
-	KLVs *jets = fi.Get<KLVs>(names[0]);
-	KBeamSpot *bs = fi.Get<KBeamSpot>("offlineBeamSpot");
+	KLVs *jets = fi.GetEvent<KLVs>(names[0]);
+	KBeamSpot *bs = fi.GetEvent<KBeamSpot>("offlineBeamSpot");
 
 	std::map<std::string, KLVs*> tomap;
 	for (size_t i = 0; i < names.size(); ++i)
-		tomap[names[i]] = fi.Get<KLVs>(names[i]);
+		tomap[names[i]] = fi.GetEvent<KLVs>(names[i]);
 
-	KEventInfo *meta_event = fi.Get<KEventInfo>();
+	KEventInfo *meta_event = fi.GetEvent<KEventInfo>();
 
 //	long long nEvents = min((long long)3, fi.eventdata->GetEntries());
 	long long nEvents = fi.eventdata->GetEntries();
@@ -53,8 +53,8 @@ int main(int argc, char **argv)
 		static LSWatcher lsWatcher;
 		if (lsWatcher.Changed(meta_event))
 			cout << "Reading new lumi metadata!" << endl;
-		KLumiInfo *meta_lumi = fi.Get<KLumiInfo>(meta_event);
-		KGenRunInfo *meta_lumi_gen = fi.Get<KGenRunInfo>(meta_event);
+		KLumiInfo *meta_lumi = fi.GetEvent<KLumiInfo>(meta_event);
+		KGenRunInfo *meta_lumi_gen = fi.GetEvent<KGenRunInfo>(meta_event);
 
 		if (meta_event->bitsHLT.size() == 0)
 			continue;

--- a/RootTools/interface/Directory.h
+++ b/RootTools/interface/Directory.h
@@ -39,7 +39,7 @@ std::map<std::string, T*> GetDirObjectsMap(TDirectory *dir)
 	return result;
 }
 
-std::vector<std::string> TreeObjects(TTree &chain, const std::string cname, const bool inherited = false);
+std::vector<std::string> TreeObjects(TTree* chain, const std::string cname, const bool inherited = false);
 bool CheckBranch(TBranch *branch, const std::string cname, bool checkDict);
 bool CheckType(const std::string req, const std::string cur);
 

--- a/RootTools/interface/DisplayTools.h
+++ b/RootTools/interface/DisplayTools.h
@@ -11,7 +11,7 @@
 #include <stddef.h>
 #include <cstring>
 
-void displayWeight(KGenLumiInfo *infoLumi, KGenEventInfo *infoEvent);
+void displayWeight(KGenRunInfo *infoLumi, KGenEventInfo *infoEvent);
 void displayBits(KEventInfo *info);
 void displayHLT(KLumiInfo *infoLumi, KEventInfo *infoEvent);
 

--- a/RootTools/interface/FileInterface.h
+++ b/RootTools/interface/FileInterface.h
@@ -16,10 +16,7 @@ class FileInterface : public FileInterfaceBase
 {
 public:
 	FileInterface(std::vector<std::string> files, bool shuffle = false, int verbose = 2);
-	~FileInterface()
-	{
-		ClearCache();
-	}
+	~FileInterface();
 	using FileInterfaceBase::Get;
 
 	// Functions for getting metadata objects

--- a/RootTools/interface/FileInterface.h
+++ b/RootTools/interface/FileInterface.h
@@ -17,13 +17,13 @@ class FileInterface : public FileInterfaceBase
 public:
 	FileInterface(std::vector<std::string> files, bool shuffle = false, int verbose = 2);
 	~FileInterface();
-	using FileInterfaceBase::Get;
+	using FileInterfaceBase::GetEvent;
 
 	// Functions for getting metadata objects
 	template<typename T>
-	T *Get(run_id run, lumi_id lumi);
+	T *GetEvent(run_id run, lumi_id lumi);
 	template<typename T>
-	inline T *Get(KEventInfo *info_event);
+	inline T *GetEvent(KEventInfo *info_event);
 
 	// Get lumi list
 	std::vector<std::pair<run_id, lumi_id> > GetRunLumis() const;

--- a/RootTools/interface/FileInterface.h
+++ b/RootTools/interface/FileInterface.h
@@ -35,9 +35,10 @@ public:
 	TChain eventdata;
 private:
 	TChain lumidata;
+	TChain rundata;
 	int verbosity;
 
-	std::map<std::pair<run_id, lumi_id>, KGenLumiInfo> lumimap_mc;
+	std::map<std::pair<run_id, lumi_id>, KGenRunInfo> lumimap_mc;
 	std::map<std::pair<run_id, lumi_id>, KLumiInfo> lumimap_std;
 	std::map<std::pair<run_id, lumi_id>, KDataLumiInfo> lumimap_data;
 

--- a/RootTools/interface/FileInterface.h
+++ b/RootTools/interface/FileInterface.h
@@ -30,9 +30,11 @@ public:
 	bool isCompatible(unsigned int minRun, unsigned int maxRun);
 
 	TChain eventdata;
+	
 private:
 	TChain lumidata;
 	TChain rundata;
+	
 	int verbosity;
 
 	std::map<std::pair<run_id, lumi_id>, KGenRunInfo> lumimap_mc;

--- a/RootTools/interface/FileInterface.hxx
+++ b/RootTools/interface/FileInterface.hxx
@@ -14,7 +14,7 @@ T *FileInterface::Get(run_id run, lumi_id lumi)
 template<>
 KLumiInfo *FileInterface::Get(run_id run, lumi_id lumi);
 template<>
-KGenLumiInfo *FileInterface::Get(run_id run, lumi_id lumi);
+KGenRunInfo *FileInterface::Get(run_id run, lumi_id lumi);
 template<>
 KDataLumiInfo *FileInterface::Get(run_id run, lumi_id lumi);
 

--- a/RootTools/interface/FileInterface.hxx
+++ b/RootTools/interface/FileInterface.hxx
@@ -5,18 +5,18 @@
 
 // Get lumi metadata objects
 template<typename T>
-T *FileInterface::Get(run_id run, lumi_id lumi)
+T *FileInterface::GetEvent(run_id run, lumi_id lumi)
 {
 	std::cerr << "Unsupported lumi metadata type: " << TypeName<T>::name() << std::endl;
 	return 0;
 }
 
 template<>
-KLumiInfo *FileInterface::Get(run_id run, lumi_id lumi);
+KLumiInfo *FileInterface::GetEvent(run_id run, lumi_id lumi);
 template<>
-KGenRunInfo *FileInterface::Get(run_id run, lumi_id lumi);
+KGenRunInfo *FileInterface::GetEvent(run_id run, lumi_id lumi);
 template<>
-KDataLumiInfo *FileInterface::Get(run_id run, lumi_id lumi);
+KDataLumiInfo *FileInterface::GetEvent(run_id run, lumi_id lumi);
 
 template<typename T>
 std::map<std::pair<run_id, lumi_id>, T> FileInterface::GetLumis()
@@ -75,7 +75,7 @@ std::map<std::pair<run_id, lumi_id>, T> FileInterface::GetLumis()
 }
 
 template<typename T>
-inline T *FileInterface::Get(KEventInfo *info_event)
+inline T *FileInterface::GetEvent(KEventInfo *info_event)
 {
-	return this->Get<T>(info_event->nRun, info_event->nLumi);
+	return this->GetEvent<T>(info_event->nRun, info_event->nLumi);
 }

--- a/RootTools/interface/FileInterface2.h
+++ b/RootTools/interface/FileInterface2.h
@@ -26,6 +26,9 @@ public:
 		for (std::map<std::string, BranchHolder*>::iterator it = meta_branches.begin(); it != meta_branches.end(); ++it)
 			delete it->second;
 		meta_branches.clear();
+		for (std::map<std::string, BranchHolder*>::iterator it = run_branches.begin(); it != run_branches.end(); ++it)
+			delete it->second;
+		run_branches.clear();
 		ClearCache();
 		delete lumidata;
 	}
@@ -34,6 +37,8 @@ public:
 	// Functions for accessing metadata objects
 	void GetMetaEntry();
 	void GetMetaEntry(run_id run, lumi_id lumi);
+	void GetRunEntry();
+	void GetRunEntry(run_id run);
 
 	// Functions for getting metadata objects
 	template<typename T>
@@ -42,6 +47,10 @@ public:
 	std::vector<std::string> GetMetaNames(bool inherited = false);
 	template<typename T>
 	std::map<std::string, T*> GetMetaAll(bool inherited = false);
+
+	// Functions for getting metadata objects
+	template<typename T>
+	T *GetRun(std::string name, const bool check = true, const bool def = false);
 
 	// Functions for getting metadata objects - old style
 	template<typename T>
@@ -53,8 +62,11 @@ public:
 
 protected:
 	TChain *lumidata;
+	TChain *rundata;
 	std::string current_file;
+	std::string current_run_file;
 	std::map<std::string, BranchHolder*> meta_branches;
+	std::map<std::string, BranchHolder*> run_branches;
 	std::map<std::pair<run_id, lumi_id>, size_t> lumiIdxMap;
 };
 

--- a/RootTools/interface/FileInterface2.h
+++ b/RootTools/interface/FileInterface2.h
@@ -22,21 +22,21 @@ public:
 	FileInterface2(std::vector<std::string> files, class RunLumiSelector *rls = nullptr,
 		bool shuffle = false, int verbose = 2, class ScaleServiceFactory *ss = nullptr, std::string reportFn = "");
 	~FileInterface2();
-	using FileInterfaceBase::Get;
+	using FileInterfaceBase::GetEvent;
 
 	// Functions for accessing metadata objects
-	void GetMetaEntry();
-	void GetMetaEntry(run_id run, lumi_id lumi);
+	void GetLumiEntry();
+	void GetLumiEntry(run_id run, lumi_id lumi);
 	void GetRunEntry();
 	void GetRunEntry(run_id run);
 
 	// Functions for getting metadata objects
 	template<typename T>
-	T *GetMeta(std::string name, const bool check = true, const bool def = false);
+	T *GetLumi(std::string name, const bool check = true, const bool def = false);
 	template<typename T>
-	std::vector<std::string> GetMetaNames(bool inherited = false);
+	std::vector<std::string> GetLumiNames(bool inherited = false);
 	template<typename T>
-	std::map<std::string, T*> GetMetaAll(bool inherited = false);
+	std::map<std::string, T*> GetLumiAll(bool inherited = false);
 
 	// Functions for getting metadata objects
 	template<typename T>
@@ -44,17 +44,18 @@ public:
 
 	// Functions for getting metadata objects - old style
 	template<typename T>
-	T *Get(run_id run, lumi_id lumi);
+	T *GetEvent(run_id run, lumi_id lumi);
 	template<typename T>
-	inline T *Get(KEventInfo *meta_event);
+	inline T *GetEvent(KEventInfo *meta_event);
 
 protected:
 	TChain* lumidata = nullptr;
 	TChain* rundata = nullptr;
-	std::string current_file;
-	std::string current_run_file;
-	std::map<std::string, BranchHolder*> meta_branches;
-	std::map<std::string, BranchHolder*> run_branches;
+	
+	std::string currentLumiFile;
+	std::string currentRunFile;
+	std::map<std::string, BranchHolder*> lumiBranches;
+	std::map<std::string, BranchHolder*> runBranches;
 	std::map<std::pair<run_id, lumi_id>, size_t> lumiIdxMap;
 	std::map<run_id, size_t> runIdxMap;
 };

--- a/RootTools/interface/FileInterface2.h
+++ b/RootTools/interface/FileInterface2.h
@@ -21,17 +21,7 @@ class FileInterface2 : public FileInterfaceBase
 public:
 	FileInterface2(std::vector<std::string> files, class RunLumiSelector *rls = nullptr,
 		bool shuffle = false, int verbose = 2, class ScaleServiceFactory *ss = nullptr, std::string reportFn = "");
-	~FileInterface2()
-	{
-		for (std::map<std::string, BranchHolder*>::iterator it = meta_branches.begin(); it != meta_branches.end(); ++it)
-			delete it->second;
-		meta_branches.clear();
-		for (std::map<std::string, BranchHolder*>::iterator it = run_branches.begin(); it != run_branches.end(); ++it)
-			delete it->second;
-		run_branches.clear();
-		ClearCache();
-		delete lumidata;
-	}
+	~FileInterface2();
 	using FileInterfaceBase::Get;
 
 	// Functions for accessing metadata objects

--- a/RootTools/interface/FileInterface2.h
+++ b/RootTools/interface/FileInterface2.h
@@ -48,16 +48,15 @@ public:
 	template<typename T>
 	inline T *Get(KEventInfo *meta_event);
 
-	TChain eventdata;
-
 protected:
-	TChain *lumidata;
-	TChain *rundata;
+	TChain* lumidata = nullptr;
+	TChain* rundata = nullptr;
 	std::string current_file;
 	std::string current_run_file;
 	std::map<std::string, BranchHolder*> meta_branches;
 	std::map<std::string, BranchHolder*> run_branches;
 	std::map<std::pair<run_id, lumi_id>, size_t> lumiIdxMap;
+	std::map<run_id, size_t> runIdxMap;
 };
 
 #include "FileInterface2.hxx"

--- a/RootTools/interface/FileInterface2.hxx
+++ b/RootTools/interface/FileInterface2.hxx
@@ -2,18 +2,6 @@
  *   Fred Stober <stober@cern.ch>
  */
 
-// Get lumi metadata objects
-template<typename T>
-T *FileInterface2::GetLumi(std::string name, const bool check, const bool def)
-{
-	if (name == "")
-		name = TypeName<T>::name();
-	T *result = static_cast<T*>(GetInternal(lumidata, lumiBranches, TypeName<T>::name(), name, check));
-	if ((result == nullptr) && def)
-		return new T();
-	return result;
-}
-
 template<typename T>
 std::vector<std::string> FileInterface2::GetLumiNames(bool inherited)
 {
@@ -44,6 +32,19 @@ inline T *FileInterface2::GetEvent(KEventInfo *info_event)
 	GetLumiEntry(info_event->nRun, info_event->nLumi);
 	return GetLumi<T>("lumiInfo");
 }
+
+// Get lumi metadata objects
+template<typename T>
+T *FileInterface2::GetLumi(std::string name, const bool check, const bool def)
+{
+	if (name == "")
+		name = TypeName<T>::name();
+	T *result = static_cast<T*>(GetInternal(lumidata, lumiBranches, TypeName<T>::name(), name, check));
+	if ((result == nullptr) && def)
+		return new T();
+	return result;
+}
+
 // Get run metadata objects
 template<typename T>
 T *FileInterface2::GetRun(std::string name, const bool check, const bool def)

--- a/RootTools/interface/FileInterface2.hxx
+++ b/RootTools/interface/FileInterface2.hxx
@@ -44,3 +44,14 @@ inline T *FileInterface2::Get(KEventInfo *info_event)
 	GetMetaEntry(info_event->nRun, info_event->nLumi);
 	return GetMeta<T>("lumiInfo");
 }
+// Get run metadata objects
+template<typename T>
+T *FileInterface2::GetRun(std::string name, const bool check, const bool def)
+{
+	if (name == "")
+		name = TypeName<T>::name();
+	T *result = static_cast<T*>(GetInternal(rundata, run_branches, TypeName<T>::name(), name, check));
+	if ((result == nullptr) && def)
+		return new T();
+	return result;
+}

--- a/RootTools/interface/FileInterface2.hxx
+++ b/RootTools/interface/FileInterface2.hxx
@@ -4,45 +4,45 @@
 
 // Get lumi metadata objects
 template<typename T>
-T *FileInterface2::GetMeta(std::string name, const bool check, const bool def)
+T *FileInterface2::GetLumi(std::string name, const bool check, const bool def)
 {
 	if (name == "")
 		name = TypeName<T>::name();
-	T *result = static_cast<T*>(GetInternal(lumidata, meta_branches, TypeName<T>::name(), name, check));
+	T *result = static_cast<T*>(GetInternal(lumidata, lumiBranches, TypeName<T>::name(), name, check));
 	if ((result == nullptr) && def)
 		return new T();
 	return result;
 }
 
 template<typename T>
-std::vector<std::string> FileInterface2::GetMetaNames(bool inherited)
+std::vector<std::string> FileInterface2::GetLumiNames(bool inherited)
 {
 	return TreeObjects(lumidata, TypeName<T>::name(), inherited);
 }
 
 template<typename T>
-std::map<std::string, T*> FileInterface2::GetMetaAll(bool inherited)
+std::map<std::string, T*> FileInterface2::GetLumiAll(bool inherited)
 {
 	std::map<std::string, T*> result;
-	std::vector<std::string> names = GetMetaNames<T>(inherited);
+	std::vector<std::string> names = GetLumiNames<T>(inherited);
 	for (std::vector<std::string>::const_iterator it = names.begin(); it < names.end(); ++it)
-		result[*it] = GetMeta<T>(*it);
+		result[*it] = GetLumi<T>(*it);
 	return result;
 }
 
 // Get lumi metadata objects - old style
 template<typename T>
-T *FileInterface2::Get(run_id run, lumi_id lumi)
+T *FileInterface2::GetEvent(run_id run, lumi_id lumi)
 {
-	GetMetaEntry(run, lumi);
-	return GetMeta<T>("lumiInfo");
+	GetLumiEntry(run, lumi);
+	return GetLumi<T>("lumiInfo");
 }
 
 template<typename T>
-inline T *FileInterface2::Get(KEventInfo *info_event)
+inline T *FileInterface2::GetEvent(KEventInfo *info_event)
 {
-	GetMetaEntry(info_event->nRun, info_event->nLumi);
-	return GetMeta<T>("lumiInfo");
+	GetLumiEntry(info_event->nRun, info_event->nLumi);
+	return GetLumi<T>("lumiInfo");
 }
 // Get run metadata objects
 template<typename T>
@@ -50,7 +50,7 @@ T *FileInterface2::GetRun(std::string name, const bool check, const bool def)
 {
 	if (name == "")
 		name = TypeName<T>::name();
-	T *result = static_cast<T*>(GetInternal(rundata, run_branches, TypeName<T>::name(), name, check));
+	T *result = static_cast<T*>(GetInternal(rundata, runBranches, TypeName<T>::name(), name, check));
 	if ((result == nullptr) && def)
 		return new T();
 	return result;

--- a/RootTools/interface/FileInterface2.hxx
+++ b/RootTools/interface/FileInterface2.hxx
@@ -17,7 +17,7 @@ T *FileInterface2::GetMeta(std::string name, const bool check, const bool def)
 template<typename T>
 std::vector<std::string> FileInterface2::GetMetaNames(bool inherited)
 {
-	return TreeObjects(*lumidata, TypeName<T>::name(), inherited);
+	return TreeObjects(lumidata, TypeName<T>::name(), inherited);
 }
 
 template<typename T>

--- a/RootTools/interface/FileInterface2Adv.h
+++ b/RootTools/interface/FileInterface2Adv.h
@@ -41,7 +41,7 @@ public:
 		if (output_file == 0)
 			return;
 		if (output_event == 0)
-			output_event = CloneTreeContent("Events", branches);
+			output_event = CloneTreeContent("Events", eventBranches);
 		output_event->Fill();
 	}
 
@@ -51,7 +51,7 @@ public:
 		if (output_file == 0)
 			return;
 		if (output_lumi == 0)
-			output_lumi = CloneTreeContent("Lumis", meta_branches);
+			output_lumi = CloneTreeContent("Lumis", lumiBranches);
 		output_lumi->Fill();
 	}
 

--- a/RootTools/interface/FileInterfaceBase.h
+++ b/RootTools/interface/FileInterfaceBase.h
@@ -24,18 +24,18 @@ public:
 			delete it->second;
 		branches.clear();
 	}
-	void Init(TChain *_eventchain, DataType _lumiInfoType);
+	void Init(TChain *_eventdata, DataType _lumiInfoType);
 
 	void SpeedupTree(long cache = 0);
-	TChain *eventchain;
+	TChain *eventdata;
 
 	inline long long GetEntries()
 	{
-		return eventchain->GetEntries();
+		return eventdata->GetEntries();
 	}
 	inline void GetEntry(long long entry)
 	{
-		eventchain->GetEntry(entry);
+		eventdata->GetEntry(entry);
 	}
 
 	// Functions for getting metadata objects

--- a/RootTools/interface/FileInterfaceBase.h
+++ b/RootTools/interface/FileInterfaceBase.h
@@ -20,9 +20,9 @@ public:
 	FileInterfaceBase(int verbose = 2);
 	void ClearCache()
 	{
-		for (std::map<std::string, BranchHolder*>::iterator it = branches.begin(); it != branches.end(); ++it)
+		for (std::map<std::string, BranchHolder*>::iterator it = eventBranches.begin(); it != eventBranches.end(); ++it)
 			delete it->second;
-		branches.clear();
+		eventBranches.clear();
 	}
 	void Init(TChain* _eventdata, DataType _lumiInfoType);
 
@@ -32,22 +32,22 @@ public:
 	{
 		return eventdata->GetEntries();
 	}
-	inline void GetEntry(long long entry)
+	inline void GetEventEntry(long long entry)
 	{
 		eventdata->GetEntry(entry);
 	}
 
 	// Functions for getting metadata objects
 	template<typename T>
-	T *Get();
+	T *GetEvent();
 
 	// Get event content of files
 	template<typename T>
-	T *Get(const std::string &name, const bool check = true, const bool def = false);
+	T *GetEvent(const std::string &name, const bool check = true, const bool def = false);
 	template<typename T>
-	std::vector<std::string> GetNames(bool inherited = false);
+	std::vector<std::string> GetEventNames(bool inherited = false);
 	template<typename T>
-	std::map<std::string, T*> GetAll(bool inherited = false);
+	std::map<std::string, T*> GetEventAll(bool inherited = false);
 
 	bool isMC() const;
 	
@@ -56,7 +56,7 @@ public:
 protected:
 	int verbosity;
 	KEventInfo *current_event;
-	std::map<std::string, BranchHolder*> branches;
+	std::map<std::string, BranchHolder*> eventBranches;
 
 	void *GetInternal(TTree* tree, std::map<std::string, BranchHolder*> &bmap,
 		const std::string cname, const std::string &name, const bool check = true);

--- a/RootTools/interface/FileInterfaceBase.h
+++ b/RootTools/interface/FileInterfaceBase.h
@@ -24,10 +24,9 @@ public:
 			delete it->second;
 		branches.clear();
 	}
-	void Init(TChain *_eventdata, DataType _lumiInfoType);
+	void Init(TChain* _eventdata, DataType _lumiInfoType);
 
 	void SpeedupTree(long cache = 0);
-	TChain *eventdata;
 
 	inline long long GetEntries()
 	{
@@ -51,13 +50,15 @@ public:
 	std::map<std::string, T*> GetAll(bool inherited = false);
 
 	bool isMC() const;
+	
+	TChain* eventdata = nullptr;
 
 protected:
 	int verbosity;
 	KEventInfo *current_event;
 	std::map<std::string, BranchHolder*> branches;
 
-	void *GetInternal(TTree *tree, std::map<std::string, BranchHolder*> &bmap,
+	void *GetInternal(TTree* tree, std::map<std::string, BranchHolder*> &bmap,
 		const std::string cname, const std::string &name, const bool check = true);
 };
 

--- a/RootTools/interface/FileInterfaceBase.hxx
+++ b/RootTools/interface/FileInterfaceBase.hxx
@@ -4,33 +4,33 @@
 
 // Get event metadata objects
 template<typename T>
-T *FileInterfaceBase::Get()
+T *FileInterfaceBase::GetEvent()
 {
-	return Get<T>("eventInfo");
+	return GetEvent<T>("eventInfo");
 }
 
 // Get event content from files
 template<typename T>
-T *FileInterfaceBase::Get(const std::string &name, const bool check, const bool def)
+T *FileInterfaceBase::GetEvent(const std::string &name, const bool check, const bool def)
 {
-	T *result = static_cast<T*>(GetInternal(eventdata, branches, TypeName<T>::name(), name, check));
+	T *result = static_cast<T*>(GetInternal(eventdata, eventBranches, TypeName<T>::name(), name, check));
 	if ((result == nullptr) && def)
 		return new T();
 	return result;
 }
 
 template<typename T>
-std::vector<std::string> FileInterfaceBase::GetNames(bool inherited)
+std::vector<std::string> FileInterfaceBase::GetEventNames(bool inherited)
 {
 	return TreeObjects(eventdata, TypeName<T>::name(), inherited);
 }
 
 template<typename T>
-std::map<std::string, T*> FileInterfaceBase::GetAll(bool inherited)
+std::map<std::string, T*> FileInterfaceBase::GetEventAll(bool inherited)
 {
 	std::map<std::string, T*> result;
-	std::vector<std::string> names = GetNames<T>(inherited);
+	std::vector<std::string> names = GetEventNames<T>(inherited);
 	for (std::vector<std::string>::const_iterator it = names.begin(); it < names.end(); ++it)
-		result[*it] = Get<T>(*it);
+		result[*it] = GetEvent<T>(*it);
 	return result;
 }

--- a/RootTools/interface/FileInterfaceBase.hxx
+++ b/RootTools/interface/FileInterfaceBase.hxx
@@ -22,7 +22,7 @@ T *FileInterfaceBase::Get(const std::string &name, const bool check, const bool 
 template<typename T>
 std::vector<std::string> FileInterfaceBase::GetNames(bool inherited)
 {
-	return TreeObjects(*eventdata, TypeName<T>::name(), inherited);
+	return TreeObjects(eventdata, TypeName<T>::name(), inherited);
 }
 
 template<typename T>

--- a/RootTools/interface/FileInterfaceBase.hxx
+++ b/RootTools/interface/FileInterfaceBase.hxx
@@ -13,7 +13,7 @@ T *FileInterfaceBase::Get()
 template<typename T>
 T *FileInterfaceBase::Get(const std::string &name, const bool check, const bool def)
 {
-	T *result = static_cast<T*>(GetInternal(eventchain, branches, TypeName<T>::name(), name, check));
+	T *result = static_cast<T*>(GetInternal(eventdata, branches, TypeName<T>::name(), name, check));
 	if ((result == nullptr) && def)
 		return new T();
 	return result;
@@ -22,7 +22,7 @@ T *FileInterfaceBase::Get(const std::string &name, const bool check, const bool 
 template<typename T>
 std::vector<std::string> FileInterfaceBase::GetNames(bool inherited)
 {
-	return TreeObjects(*eventchain, TypeName<T>::name(), inherited);
+	return TreeObjects(*eventdata, TypeName<T>::name(), inherited);
 }
 
 template<typename T>

--- a/RootTools/interface/JECTools.h
+++ b/RootTools/interface/JECTools.h
@@ -114,8 +114,8 @@ class JECService
 public:
 	JECService(FileInterfaceBase &fi, const std::string prefix, const std::vector<std::string> &level, const double R, const int jeuDir = 0, std::string const &pu_density_branch = "KT6Area")
 		: area(M_PI * sqr(R)), jeuType(jec_center), JEC(nullptr), JEU(nullptr),
-			vs(fi.Get<KVertexSummary>("offlinePrimaryVerticesSummary", false)),
-			ja(fi.Get<KPileupDensity>(pu_density_branch, true, true))
+			vs(fi.GetEvent<KVertexSummary>("offlinePrimaryVerticesSummary", false)),
+			ja(fi.GetEvent<KPileupDensity>(pu_density_branch, true, true))
 	{
 		if (R < 0)
 			area = -1;

--- a/RootTools/interface/ScaleService.h
+++ b/RootTools/interface/ScaleService.h
@@ -118,7 +118,7 @@ class ScaleServiceFactory
 public:
 	ScaleServiceFactory(const bool _doPrescales = true, TH1D *pu_data = 0, TH1D *pu_mc = 0) {};
 
-	void registerMC(KGenLumiInfo *info_lumi) {};
+	void registerMC(KLumiInfo *info_lumi) {};
 	void registerData(KDataLumiInfo *info_lumi) {};
 	void registerLF(std::string lumiPath) {};
 	ScaleService *finish(unsigned long long events, const double userXsec = -1, const double userLumi = -1) { return 0; };

--- a/RootTools/src/Directory.cpp
+++ b/RootTools/src/Directory.cpp
@@ -25,10 +25,10 @@ std::map<std::string, TObject*> GetDirObjectsMap(TDirectory *dir)
 	return result;
 }
 
-std::vector<std::string> TreeObjects(TTree &chain, const std::string cname, const bool inherited)
+std::vector<std::string> TreeObjects(TTree* chain, const std::string cname, const bool inherited)
 {
 	std::vector<std::string> result;
-	TObjArray *branches = chain.GetListOfBranches();
+	TObjArray *branches = chain->GetListOfBranches();
 	if (branches == 0)
 		return result;
 	TClass *req = TClass::GetClass(cname.c_str());

--- a/RootTools/src/DisplayTools.cpp
+++ b/RootTools/src/DisplayTools.cpp
@@ -5,7 +5,7 @@
 #include "../interface/DisplayTools.h"
 #include <bitset>
 
-void displayWeight(KGenLumiInfo *infoLumi, KGenEventInfo *infoEvent)
+void displayWeight(KGenRunInfo *infoLumi, KGenEventInfo *infoEvent)
 {
 	std::cout << "Ext: " << infoLumi->xSectionExt << " Int: " << infoLumi->xSectionInt
 		<< " W: " << infoEvent->weight << std::endl;

--- a/RootTools/src/FileInterface.cpp
+++ b/RootTools/src/FileInterface.cpp
@@ -44,6 +44,11 @@ FileInterface::FileInterface(vector<string> files, bool shuffle, int verbose) :
 	}
 }
 
+FileInterface::~FileInterface()
+{
+	ClearCache();
+}
+
 template<typename T>
 inline bool isCompatible(const std::map<std::pair<run_id, lumi_id>, T> &lumimap, unsigned int minRun, unsigned int maxRun)
 {

--- a/RootTools/src/FileInterface.cpp
+++ b/RootTools/src/FileInterface.cpp
@@ -100,7 +100,7 @@ std::vector<std::pair<run_id, lumi_id> > FileInterface::GetRunLumis() const
 }
 
 template<>
-KLumiInfo *FileInterface::Get(run_id run, lumi_id lumi)
+KLumiInfo *FileInterface::GetEvent(run_id run, lumi_id lumi)
 {
 	switch (lumiInfoType)
 	{
@@ -118,7 +118,7 @@ KLumiInfo *FileInterface::Get(run_id run, lumi_id lumi)
 }
 
 template<>
-KGenRunInfo *FileInterface::Get(run_id run, lumi_id lumi)
+KGenRunInfo *FileInterface::GetEvent(run_id run, lumi_id lumi)
 {
 	if (lumiInfoType == GEN)
 		return &(lumimap_mc[std::make_pair(run, lumi)]);
@@ -126,7 +126,7 @@ KGenRunInfo *FileInterface::Get(run_id run, lumi_id lumi)
 }
 
 template<>
-KDataLumiInfo *FileInterface::Get(run_id run, lumi_id lumi)
+KDataLumiInfo *FileInterface::GetEvent(run_id run, lumi_id lumi)
 {
 	if (lumiInfoType == DATA)
 		return &(lumimap_data[std::make_pair(run, lumi)]);

--- a/RootTools/src/FileInterface.cpp
+++ b/RootTools/src/FileInterface.cpp
@@ -10,7 +10,7 @@
 using namespace std;
 
 FileInterface::FileInterface(vector<string> files, bool shuffle, int verbose) :
-	eventdata("Events"), lumidata("Lumis"), verbosity(verbose)
+	eventdata("Events"), lumidata("Lumis"), rundata("Runs"), verbosity(verbose)
 {
 	if (shuffle)
 		random_shuffle(files.begin(), files.end());
@@ -20,17 +20,13 @@ FileInterface::FileInterface(vector<string> files, bool shuffle, int verbose) :
 			cout << "Loading ... " << files[i] << endl;
 		eventdata.Add(files[i].c_str());
 		lumidata.Add(files[i].c_str());
+		rundata.Add(files[i].c_str());
 	}
 
 	TBranch *b = lumidata.GetBranch("lumiInfo");
 	if (b)
 	{
-		if (string(b->GetClassName()) == "KGenLumiInfo")
-		{
-			Init(&eventdata, GEN);
-			lumimap_mc = GetLumis<KGenLumiInfo>();
-		}
-		else if (string(b->GetClassName()) == "KDataLumiInfo")
+		if (string(b->GetClassName()) == "KDataLumiInfo")
 		{
 			Init(&eventdata, DATA);
 			lumimap_data = GetLumis<KDataLumiInfo>();
@@ -104,7 +100,8 @@ KLumiInfo *FileInterface::Get(run_id run, lumi_id lumi)
 	switch (lumiInfoType)
 	{
 	case GEN:
-		return &(lumimap_mc[std::make_pair(run, lumi)]);
+		//return &(lumimap_mc[std::make_pair(run, lumi)]);
+		return &(lumimap_std[std::make_pair(run, lumi)]);
 	case STD:
 		return &(lumimap_std[std::make_pair(run, lumi)]);
 	case DATA:
@@ -116,7 +113,7 @@ KLumiInfo *FileInterface::Get(run_id run, lumi_id lumi)
 }
 
 template<>
-KGenLumiInfo *FileInterface::Get(run_id run, lumi_id lumi)
+KGenRunInfo *FileInterface::Get(run_id run, lumi_id lumi)
 {
 	if (lumiInfoType == GEN)
 		return &(lumimap_mc[std::make_pair(run, lumi)]);

--- a/RootTools/src/FileInterface2.cpp
+++ b/RootTools/src/FileInterface2.cpp
@@ -28,7 +28,7 @@ void updateSSF(ScaleServiceFactory *ss, FileInterfaceBase::DataType dt, KLumiInf
 
 FileInterface2::FileInterface2(std::vector<std::string> files, RunLumiSelector *rls,
 	bool shuffle, int verbose, ScaleServiceFactory *ss, std::string reportFn)
-	: FileInterfaceBase(verbose), lumidata(new TChain("Lumis")), rundata(new TChain("Runs")), current_file()
+	: FileInterfaceBase(verbose), lumidata(new TChain("Lumis")), rundata(new TChain("Runs")), currentLumiFile(), currentRunFile()
 {
 	eventdata = new TChain("Events");
 	
@@ -91,11 +91,11 @@ FileInterface2::FileInterface2(std::vector<std::string> files, RunLumiSelector *
 
 		// 3) add accepted files to chain / persistent lumi info list
 		usedFiles.push_back(files[f]);
-		bool open_succesfully;
-		open_succesfully = eventdata->Add(files[f].c_str(),-1);
+		
+		bool open_succesfully = eventdata->Add(files[f].c_str(),-1);
 		if (open_succesfully != 1)
 		{
-			std::cerr << "File " << files[f] << " could not be accessed!" << std::endl;
+			std::cerr << "Tree " << files[f] << "/Events could not be accessed!" << std::endl;
 			exit(1);
 		}
 	
@@ -117,20 +117,20 @@ FileInterface2::FileInterface2(std::vector<std::string> files, RunLumiSelector *
 	Init(eventdata, dtAll);
 	if (current_event != 0)
 	{
-		GetEntry(0);
-		GetMetaEntry();
+		GetEventEntry(0);
+		GetLumiEntry();
 		GetRunEntry();
 	}
 }
 
 FileInterface2::~FileInterface2()
 {
-	for (std::map<std::string, BranchHolder*>::iterator it = meta_branches.begin(); it != meta_branches.end(); ++it)
+	for (std::map<std::string, BranchHolder*>::iterator it = lumiBranches.begin(); it != lumiBranches.end(); ++it)
 		delete it->second;
-	meta_branches.clear();
-	for (std::map<std::string, BranchHolder*>::iterator it = run_branches.begin(); it != run_branches.end(); ++it)
+	lumiBranches.clear();
+	for (std::map<std::string, BranchHolder*>::iterator it = runBranches.begin(); it != runBranches.end(); ++it)
 		delete it->second;
-	run_branches.clear();
+	runBranches.clear();
 	ClearCache();
 	
 	if (eventdata) delete eventdata;
@@ -138,39 +138,39 @@ FileInterface2::~FileInterface2()
 	if (rundata) delete rundata;
 }
 
-void FileInterface2::GetMetaEntry()
+void FileInterface2::GetLumiEntry()
 {
-	GetMetaEntry(current_event->nRun, current_event->nLumi);
+	GetLumiEntry(current_event->nRun, current_event->nLumi);
 }
 
-void FileInterface2::GetMetaEntry(run_id run, lumi_id lumi)
+void FileInterface2::GetLumiEntry(run_id run, lumi_id lumi)
 {
-	if (eventdata->GetFile()->GetName() != current_file)
+	if (eventdata->GetFile()->GetName() != currentLumiFile)
 	{
 		lumiIdxMap.clear();
 		// Update tree reference of booked variables
 		TChain *newLumiData = new TChain("Lumis");
 		newLumiData->Add(eventdata->GetFile()->GetName());
-		for (std::map<std::string, BranchHolder*>::iterator it = meta_branches.begin(); it != meta_branches.end(); ++it)
+		for (std::map<std::string, BranchHolder*>::iterator it = lumiBranches.begin(); it != lumiBranches.end(); ++it)
 			it->second->UpdateTree(newLumiData);
 		if (lumidata)
 			delete lumidata;
 		lumidata = newLumiData;
 		// Rebuild lumi index map
-		KLumiInfo *info_lumi = GetMeta<KLumiInfo>("lumiInfo", false, false);
+		KLumiInfo *info_lumi = GetLumi<KLumiInfo>("lumiInfo", false, false);
 		for (int i = 0; i < lumidata->GetEntries(); ++i)
 		{
 			lumidata->GetEntry(i);
 			lumiIdxMap[make_pair(info_lumi->nRun, info_lumi->nLumi)] = i;
 		}
-		current_file = eventdata->GetFile()->GetName();
+		currentLumiFile = eventdata->GetFile()->GetName();
 	}
 	if (lumiIdxMap.count(make_pair(run, lumi)) == 1)
 		lumidata->GetEntry(lumiIdxMap[make_pair(run, lumi)]);
 	else if (eventdata->GetEntries() > 0)
 	{
 		std::cerr << "Lumi section " << run << ":" << lumi << " not found or unique!" << std::endl;
-		std::cerr << eventdata->GetFile() << " " << eventdata->GetFileNumber() << " " << current_file << std::endl;
+		std::cerr << eventdata->GetFile() << " " << eventdata->GetFileNumber() << " " << currentLumiFile << std::endl;
 		std::cerr << lumiIdxMap << endl;
 		exit(1);
 	}
@@ -184,12 +184,12 @@ void FileInterface2::GetRunEntry()
 
 void FileInterface2::GetRunEntry(run_id run)
 {
-	if (eventdata->GetFile()->GetName() != current_run_file)
+	if (eventdata->GetFile()->GetName() != currentRunFile)
 	{
 		// Update tree reference of booked variables
 		TChain *newRunData = new TChain("Runs");
 		newRunData->Add(eventdata->GetFile()->GetName());
-		for (std::map<std::string, BranchHolder*>::iterator it = run_branches.begin(); it != run_branches.end(); ++it)
+		for (std::map<std::string, BranchHolder*>::iterator it = runBranches.begin(); it != runBranches.end(); ++it)
 			it->second->UpdateTree(newRunData);
 		if (rundata)
 			delete rundata;
@@ -203,6 +203,6 @@ void FileInterface2::GetRunEntry(run_id run)
 		}
 		rundata->GetEntry(0);
 		assert(rundata->GetEntries() == 1);
-		current_run_file = eventdata->GetFile()->GetName();
+		currentRunFile = eventdata->GetFile()->GetName();
 	}
 }

--- a/RootTools/src/FileInterface2.cpp
+++ b/RootTools/src/FileInterface2.cpp
@@ -178,7 +178,12 @@ void FileInterface2::GetRunEntry(run_id run)
 			delete rundata;
 		rundata = newRunData;
 		// Always get first entry. The Run tree is currently only used to store generator information, on MC there is only run "1".
-		GetRun<KGenRunInfo>("runInfo", false, false);
+		auto array = rundata->GetListOfBranches();
+		for( auto entry: *array)
+		{
+			if (std::string(entry->GetName()) == "runInfo")
+				GetRun<KGenRunInfo>("runInfo", false, false);
+		}
 		rundata->GetEntry(0);
 		assert(rundata->GetEntries() == 1);
 		current_run_file = eventdata.GetFile()->GetName();

--- a/RootTools/src/FileInterface2.cpp
+++ b/RootTools/src/FileInterface2.cpp
@@ -177,6 +177,10 @@ void FileInterface2::GetRunEntry(run_id run)
 		if (rundata)
 			delete rundata;
 		rundata = newRunData;
+		// Always get first entry. The Run tree is currently only used to store generator information, on MC there is only run "1".
+		GetRun<KGenRunInfo>("runInfo", false, false);
+		rundata->GetEntry(0);
+		assert(rundata->GetEntries() == 1);
 		current_run_file = eventdata.GetFile()->GetName();
 	}
 }

--- a/RootTools/src/FileInterface2.cpp
+++ b/RootTools/src/FileInterface2.cpp
@@ -121,6 +121,17 @@ FileInterface2::FileInterface2(std::vector<std::string> files, RunLumiSelector *
 	}
 }
 
+FileInterface2::~FileInterface2()
+{
+	for (std::map<std::string, BranchHolder*>::iterator it = meta_branches.begin(); it != meta_branches.end(); ++it)
+		delete it->second;
+	meta_branches.clear();
+	for (std::map<std::string, BranchHolder*>::iterator it = run_branches.begin(); it != run_branches.end(); ++it)
+		delete it->second;
+	run_branches.clear();
+	ClearCache();
+}
+
 void FileInterface2::GetMetaEntry()
 {
 	GetMetaEntry(current_event->nRun, current_event->nLumi);

--- a/RootTools/src/FileInterfaceBase.cpp
+++ b/RootTools/src/FileInterfaceBase.cpp
@@ -17,7 +17,7 @@ void FileInterfaceBase::Init(TChain* _eventdata, FileInterfaceBase::DataType _lu
 {
 	eventdata = _eventdata;
 	lumiInfoType = _lumiInfoType;
-	current_event = Get<KEventInfo>("eventInfo", false);
+	current_event = GetEvent<KEventInfo>("eventInfo", false);
 	assert((current_event != 0) || (eventdata->GetEntries() == 0));
 	switch (lumiInfoType)
 	{
@@ -36,12 +36,12 @@ void FileInterfaceBase::SpeedupTree(long cache)
 {
 	if (cache > 0)
 		eventdata->SetCacheSize(cache);
-	TObjArray *branches = eventdata->GetListOfBranches();
-	if (branches != 0)
+	TObjArray *eventBranches = eventdata->GetListOfBranches();
+	if (eventBranches != 0)
 	{
-		for (int i = 0; i < branches->GetEntries(); ++i)
+		for (int i = 0; i < eventBranches->GetEntries(); ++i)
 		{
-			TBranch *b = dynamic_cast<TBranch*>(branches->At(i));
+			TBranch *b = dynamic_cast<TBranch*>(eventBranches->At(i));
 			if (b->GetAddress() == 0)
 			{
 				UInt_t found = 0;

--- a/RootTools/src/FileInterfaceBase.cpp
+++ b/RootTools/src/FileInterfaceBase.cpp
@@ -13,7 +13,7 @@ FileInterfaceBase::FileInterfaceBase(int verbose) :
 {
 }
 
-void FileInterfaceBase::Init(TChain *_eventdata, FileInterfaceBase::DataType _lumiInfoType)
+void FileInterfaceBase::Init(TChain* _eventdata, FileInterfaceBase::DataType _lumiInfoType)
 {
 	eventdata = _eventdata;
 	lumiInfoType = _lumiInfoType;
@@ -62,7 +62,7 @@ void FileInterfaceBase::SpeedupTree(long cache)
 	gEnv->SetValue("TFile.AsyncPrefetching", 1);
 }
 
-void *FileInterfaceBase::GetInternal(TTree *tree, std::map<std::string, BranchHolder*> &bmap,
+void *FileInterfaceBase::GetInternal(TTree* tree, std::map<std::string, BranchHolder*> &bmap,
 	const std::string cname, const std::string &name, const bool check)
 {
 	// First time access

--- a/RootTools/src/FileInterfaceBase.cpp
+++ b/RootTools/src/FileInterfaceBase.cpp
@@ -9,16 +9,16 @@
 using namespace std;
 
 FileInterfaceBase::FileInterfaceBase(int verbose) :
-	lumiInfoType(STD), eventchain(0), verbosity(verbose)
+	lumiInfoType(STD), eventdata(0), verbosity(verbose)
 {
 }
 
-void FileInterfaceBase::Init(TChain *_eventchain, FileInterfaceBase::DataType _lumiInfoType)
+void FileInterfaceBase::Init(TChain *_eventdata, FileInterfaceBase::DataType _lumiInfoType)
 {
-	eventchain = _eventchain;
+	eventdata = _eventdata;
 	lumiInfoType = _lumiInfoType;
 	current_event = Get<KEventInfo>("eventInfo", false);
-	assert((current_event != 0) || (eventchain->GetEntries() == 0));
+	assert((current_event != 0) || (eventdata->GetEntries() == 0));
 	switch (lumiInfoType)
 	{
 		case GEN:
@@ -35,8 +35,8 @@ void FileInterfaceBase::Init(TChain *_eventchain, FileInterfaceBase::DataType _l
 void FileInterfaceBase::SpeedupTree(long cache)
 {
 	if (cache > 0)
-		eventchain->SetCacheSize(cache);
-	TObjArray *branches = eventchain->GetListOfBranches();
+		eventdata->SetCacheSize(cache);
+	TObjArray *branches = eventdata->GetListOfBranches();
 	if (branches != 0)
 	{
 		for (int i = 0; i < branches->GetEntries(); ++i)
@@ -51,14 +51,14 @@ void FileInterfaceBase::SpeedupTree(long cache)
 					bname = string(b->GetName()) + ".*";
 				else
 					bname = b->GetName();
-				eventchain->SetBranchStatus(bname.c_str(), 0, &found);
+				eventdata->SetBranchStatus(bname.c_str(), 0, &found);
 			}
 			else
 				if (cache > 0)
-					eventchain->AddBranchToCache(b); // TODO: still needed?
+					eventdata->AddBranchToCache(b); // TODO: still needed?
 		}
 	}
-	eventchain->AddBranchToCache("*", true);
+	eventdata->AddBranchToCache("*", true);
 	gEnv->SetValue("TFile.AsyncPrefetching", 1);
 }
 

--- a/Tools/bin/duplicateEventChecker.cc
+++ b/Tools/bin/duplicateEventChecker.cc
@@ -37,7 +37,7 @@ int main(int argc, char* argv[])
 
 	FileInterface kpFi(filenames, false, 2);
 	TChain &theChain = kpFi.eventdata;
-	KEventInfo *metadata = kpFi.Get<KEventInfo>();
+	KEventInfo *metadata = kpFi.GetEvent<KEventInfo>();
 	EventLogger<std::set<EventID> > log;
 
 	//now code the super-sophisticated event loop.

--- a/Tools/bin/xsec.cc
+++ b/Tools/bin/xsec.cc
@@ -22,7 +22,7 @@ int main(int argc, char **argv)
 	{
 		run_id run = lumis[l].first;
 		lumi_id lumi = lumis[l].second;
-		xsec += fi.Get<KGenRunInfo>(run, lumi)->xSectionInt;
+		xsec += fi.GetEvent<KGenRunInfo>(run, lumi)->xSectionInt;
 	}
 	cout << "Average xsec: " << xsec / lumis.size() << endl;
 

--- a/Tools/bin/xsec.cc
+++ b/Tools/bin/xsec.cc
@@ -22,7 +22,7 @@ int main(int argc, char **argv)
 	{
 		run_id run = lumis[l].first;
 		lumi_id lumi = lumis[l].second;
-		xsec += fi.Get<KGenLumiInfo>(run, lumi)->xSectionInt;
+		xsec += fi.Get<KGenRunInfo>(run, lumi)->xSectionInt;
 	}
 	cout << "Average xsec: " << xsec / lumis.size() << endl;
 


### PR DESCRIPTION
Dear colleagues,

I propose to merge the getByToken branch into the master. The changes enable the FileInterface2 to read out the Runs tree (https://github.com/KappaAnalysis/Kappa/pull/54) in analogy how the Lumis tree is read synchronised to the Events tree.

Regards,
Thomas